### PR TITLE
Bug: Formatting of lazyload looks jumpy

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -70,16 +70,16 @@ class FeatureListItem extends React.Component {
     }
     return (
       <div className='lv-tile' onClick={this.handleClick}>
-        <LazyLoad height={100} offset={30} overflow={true} resize={true}>
-          <div className='lv-tile-pic'>
+        <div className='lv-tile-pic'>
+          <LazyLoad height={100} offset={30} overflow={true} resize={true}>
             <img
               aria-label="Thumbnail Preview"
               className="list-img"
               src={f}
               onError={utils.handleMissingImage}
             />
-          </div>
-        </LazyLoad>
+          </LazyLoad>
+        </div>
         <div className="lv-tile-txt">
           <h5 className='tileArtist'>
             {this.props.artistName}


### PR DESCRIPTION
:hourglass_flowing_sand: **Hours worked:** 1.1

Small bugfix related to larger one (to be filed)

After sorting results, picture that isn't properly lazyloaded looks funny because the styled div is lazyloaded instead of just the image.

## Before
<img width="386" alt="Screen Shot 2020-02-26 at 10 11 23 AM" src="https://user-images.githubusercontent.com/305339/75358915-9ca05480-5881-11ea-9519-e0da93fd7760.png">

## After
<img width="389" alt="Screen Shot 2020-02-26 at 10 11 47 AM" src="https://user-images.githubusercontent.com/305339/75358935-a1650880-5881-11ea-97f2-84b1c88e9059.png">