### PR TITLE
Hotfix to revert Gmaps version update when using undocumented library functions.

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -148,7 +148,7 @@ class GMap extends React.Component {
 
     // See: https://engineering.universe.com/building-a-google-map-in-react-b103b4ee97f1
     const googleMapScript = document.createElement('script')
-    googleMapScript.src = `https://maps.googleapis.com/maps/api/js?key=${env.REACT_APP_GOOGLE_MAPS_API_KEY}&libraries=places`
+    googleMapScript.src = `https://maps.googleapis.com/maps/api/js?key=${env.REACT_APP_GOOGLE_MAPS_API_KEY}&libraries=places&v=quarterly`
     window.document.body.appendChild(googleMapScript)
 
     googleMapScript.addEventListener('load', () => {


### PR DESCRIPTION
:hourglass_flowing_sand: **Hours worked:** 1.25

See: https://developers.google.com/maps/documentation/javascript/versions

This postpones true fix until mid-May when the quaterly API updates as well.