### PR TITLE
Chore: Add cache headers to improve performance scores

### DIFF
--- a/static.json
+++ b/static.json
@@ -15,6 +15,15 @@
     },
     "**.png": {
       "Cache-Control": "public, max-age=31536000"
+    },
+    "**/wards.json": {
+      "Cache-Control": "public, max-age=31536000"
+    },
+    "**/ftrs.json": {
+      "Cache-Control": "public, max-age=3600"
+    },
+    "/": {
+      "Cache-Control": "no-store, no-cache"
     }
   },
   "https_only": true


### PR DESCRIPTION
:hourglass_flowing_sand: **Hours worked:** 1.5

Related: #7

I thought this was work not easily able to do with our static website, but found that it was doable using the `create-react-app-buildpack` that we're using.