### PR TITLE
Ward popup renders incorrectly in mobile view

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -637,7 +637,7 @@ export default class App extends React.Component {
       }
 
       // Only wards have this property.
-      const isArtwork = (!activeFeature.hasOwnProperty('AREA_L_CD'))
+      const isArtwork = (!activeFeature.getProperty('AREA_L_CD'))
 
       let artworkImage =
         <div className='popup-pic'>


### PR DESCRIPTION
:hourglass_flowing_sand: **Hours worked:** 0.5

▶️ **Screencast:** https://recordit.co/DU4Ks6sXvo

## Steps to Reproduce

1. Go to staging website on mobile or with narrow browser width on desktop: https://streetartto.herokuapp.com/
1. Enabled ward layer toggle.
1. Click artwork point on map. Note art showing in popup.
1. Click ward polygon on map.

## Expected

Shows popup rendered for wards.

## What happens

Shows popup rendered for artwork, but with blank data.