### PR TITLE
force check for visibility when FeatureList updates

### DIFF
--- a/src/components/App.css
+++ b/src/components/App.css
@@ -407,6 +407,7 @@ a.lv-tile:hover {
     display: block;
     margin: auto;
     overflow: auto;
+    position: relative;
   }
   .drp{
     font-size: 2.5em;

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -4,7 +4,7 @@ import 'bootstrap/dist/css/bootstrap.min.css'; // Must come first.
 import './App.css';
 import "slick-carousel/slick/slick.css";
 import "slick-carousel/slick/slick-theme.css";
-import LazyLoad from 'react-lazyload';
+import LazyLoad, { forceCheck } from 'react-lazyload';
 import ReactGA from 'react-ga';
 import 'simplebar/dist/simplebar.css';
 import sort from 'fast-sort';
@@ -96,6 +96,10 @@ class FeatureList extends React.Component {
   static propTypes = {
     features: PropTypes.arrayOf(PropTypes.object),
     onItemClick: PropTypes.func,
+  }
+
+  componentDidUpdate() {
+    forceCheck()
   }
 
   render() {


### PR DESCRIPTION
**Fixes** #29 

Lazyload checks for visibility when the component first mounts, and then on scroll or on resize. So whenever a component comes into view after the initial load but without scrolling or resizing, it won't trigger the LazyLoad component to load the image. This happens whenever the features are sorted or filtered. So to fix it, we're calling `forceCheck` whenever the FeatureList component updates.


## Definition of Done Checklist:

- [ ] Documented
- [ ] Deployed to staging
- [ ] No errors bugs/regressions introduced
- [ ] Added performance test results to PR
- [ ] Reviewed by Product Owner (via screencast) -- if appropriate
- [ ] Chore/task/feature merged into master 


## Performance Test Results

[Add the results of GTMetrix or PageSpeed Insights performance tests into the table below. You could also chose GTMetrix caches, which may be more helpful for short-lived Heroku review apps. Example:
https://github.com/hyphacoop/start-map/pull/23#issuecomment-591100189]

| Speed test | Score: [master][master] | Score: [this PR][pr] |
|----|:----:|:-----:|
| GTMetrix | [XX% / XX%][gtmetrix-master] | [XX% / XX%][gtmetrix-pr]
| PageSpeed Insights | [/100 & /100][pagespeed-master] | [/100 & /100][pagespeed-pr]


   [master]: https://streetartto.herokuapp.com/
   [pr]: #
   [gtmetrix-master]: https://gtmetrix.com/reports/
   [gtmetrix-pr]: https://gtmetrix.com/reports/
   [pagespeed-master]: https://developers.google.com/speed/pagespeed/insights/
   [pagespeed-pr]: https://developers.google.com/speed/pagespeed/insights/
