### PR TITLE
Improved readability of multiple "ands" in splash

### DIFF
--- a/src/lib/components/Splash.js
+++ b/src/lib/components/Splash.js
@@ -26,7 +26,7 @@ const Splash = ({ openSplash, closeSplash, isMobile, showSplash }) => {
             <h1 className="title">StreetARToronto - The Map!</h1>
           </div>
           <p className="text-italic">A joint project of StreetARToronto (StART) and Civic Hall Toronto</p>
-          <p>Toronto is home to some of the best mural, street and graffiti artists and art in the world. These artists and artworks have transformed Toronto's public streets, laneways and parks into a city-wide art gallery!</p>
+          <p>Toronto is home to some of the best mural, street & graffiti artists and art in the world. These artists and artworks have transformed Toronto's public streets, laneways and parks into a city-wide art gallery!</p>
           <p>This map based app will help you explore the amazing street art located throughout the city. The current database provides a sampling of murals created as part of the StreetARToronto suite of programs from 2012 to 2019. In addition to identifying the artist and arts organization responsible for painting the mural, the database describes the stories and themes behind each unique and beautiful artwork.</p>
           <p>Individually and collectively, these murals are designed to celebrate the City of Toronto motto "Diversity Our Strength" and foster a greater sense of belonging among all.</p>
           <p>Filters allow you to search by any combination of Year and/or Ward. Additional filters will be installed and the database is being updated regularly to add more artwork, so check back often!</p>


### PR DESCRIPTION
Not sure what to call this [bug?], but did initial local setup, and tripped up on this phrasing while reading the rad new splash. Feel free to close if it's not an easy call to merge.