### PR TITLE
Avoiding styling `#root` via global CSS

### DIFF
--- a/dist/assets/img/arrow.svg
+++ b/dist/assets/img/arrow.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="14" viewBox="0 0 24 24" width="14"><path d="M0 0h24v24H0z" fill="none"/><path d="M12 4l-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"/></svg>

--- a/dist/assets/img/marker-blue.svg
+++ b/dist/assets/img/marker-blue.svg
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 23.0.4, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 20 20" enable-background="new 0 0 20 20" xml:space="preserve" height="20" width="20">
-
+	 viewBox="0 0 20 20" style="enable-background:new 0 0 20 20;" xml:space="preserve" height="20" width="20">
 <style type="text/css">
-  .st0{fill:#004B84;stroke:#FFFFFF;}
+	.st0{fill:#004B84;stroke:#FFFFFF;stroke-width:2.5;}
 </style>
-<circle class="st0" cx="10.3" cy="10.3" r="8" stroke-width="2"/>
+<circle class="st0" cx="10.3" cy="10.3" r="8" stroke-width="2.5"/>
 </svg>

--- a/dist/assets/img/marker-green.svg
+++ b/dist/assets/img/marker-green.svg
@@ -4,7 +4,7 @@
 	 viewBox="0 0 20 20" enable-background="new 0 0 20 20" xml:space="preserve" height="20" width="20">
 
 <style type="text/css">
-  .st0{fill:#007F2E;stroke:#FFFFFF;}
+  .st0{fill:#007F2E;stroke:#FFFFFF;stroke-width:2.5;}
 </style>
-<circle class="st0" cx="10.3" cy="10.3" r="8" stroke-width="2"/>
+<circle class="st0" cx="10.3" cy="10.3" r="8" stroke-width="2.5"/>
 </svg>

--- a/dist/assets/img/marker-red.svg
+++ b/dist/assets/img/marker-red.svg
@@ -3,7 +3,7 @@
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 20 20" enable-background="new 0 0 20 20" xml:space="preserve" height="20" width="20">
 <style type="text/css">
-  .st0{fill:#A51631;stroke:#FFFFFF;}
+  .st0{fill:#A51631;stroke:#FFFFFF;stroke-width:2.5;}
 </style>
-<circle class="st0" cx="10.3" cy="10.3" r="8" stroke-width="2"/>
+<circle class="st0" cx="10.3" cy="10.3" r="8" stroke-width="2.5"/>
 </svg>

--- a/dist/assets/img/marker-yellow.svg
+++ b/dist/assets/img/marker-yellow.svg
@@ -3,7 +3,7 @@
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 20 20" style="enable-background:new 0 0 20 20;" xml:space="preserve" height="20" width="20">
 <style type="text/css">
-	.st0{fill:#CFB51D;stroke:#FFFFFF;}
+	.st0{fill:#CFB51D;stroke:#FFFFFF;stroke-width:2.5;}
 </style>
-<circle class="st0" cx="10.3" cy="10.3" r="8" stroke-width="2"/>
+<circle class="st0" cx="10.3" cy="10.3" r="8" stroke-width="2.5"/>
 </svg>

--- a/dist/assets/scss/_app.scss
+++ b/dist/assets/scss/_app.scss
@@ -30,7 +30,7 @@ time, mark, audio, video, button {
 	vertical-align: baseline;
 }
 
-#root, #start-map {
+#map-root, #start-map {
   width: 100%;
   height: 100%;
   display: block;
@@ -198,7 +198,7 @@ time, mark, audio, video, button {
   #nav {
     position: absolute;
     z-index: 1;
-    width: 30%;
+    width: 33%;
     min-width: 350px;
     height: calc(100% - 30px);
     display: flex;
@@ -241,6 +241,7 @@ time, mark, audio, video, button {
     padding-top: $spacing-2;
     padding-bottom: $spacing-2;
     text-align: center;
+    background: $white;
 
     img {
       margin: auto;
@@ -474,6 +475,7 @@ time, mark, audio, video, button {
     padding: $spacing-2;
     z-index: 5;
     box-shadow: -2px -2px 4px $medium-grey;
+    background: $white;
 
     .nav-items {
       display: flex;

--- a/dist/assets/scss/_responsive.scss
+++ b/dist/assets/scss/_responsive.scss
@@ -1,10 +1,11 @@
 @media only screen and (max-width : 1024px) {
-  #root, #start-map {
+  #map-root, #start-map {
     width: 100vw;
-    height: 100%;
-    position: absolute;
-    display: block;
+    height: 100vh;
+    position: fixed;
     font-size: 1em;
+    display: flex;
+    flex-direction: column;
 
     .splash-background {
       z-index: 9;
@@ -92,7 +93,6 @@
       position: absolute;
       background: $white;
       width: 100%;
-      height: 100%;
       padding: $spacing-2 $spacing-4;
       overflow: auto;
       bottom: 0;
@@ -103,15 +103,22 @@
     }
 
     main {
+      flex: 1 1 auto;
+      position: relative;
+
       &.view-map {
         .list-container {
           left: -100%;
+          bottom: 0;
+          top: 0;
         }
       }
 
       &.view-list {
         .list-container {
           left: 0;
+          bottom: 0;
+          top: 0;
         }
       }
     }

--- a/dist/assets/scss/_splash.scss
+++ b/dist/assets/scss/_splash.scss
@@ -81,7 +81,7 @@
     transition: all 0.3s ease;
     left: 0;
     z-index: 3;
-    width: 30%;
+    width: 33%;
     min-width: 350px;
     height: calc(100% - 30px);
     margin: $spacing-3;
@@ -222,6 +222,36 @@
     display: flex;
     flex-direction: column;
     justify-content: center;
+  }
+
+  .splash-footer {
+    list-style-image: url('../img/arrow.svg');
+    margin-left: 20px;
+
+    a {
+      text-transform: uppercase;
+      font-size: 0.75em;
+      letter-spacing: 2px;
+      color: $black;
+      text-decoration: none;
+      line-height: 2;
+      vertical-align: bottom;
+
+      &:hover {
+        color: $blue;
+        text-decoration: underline;
+      }
+
+      &:focus {
+        color: $red;
+      }
+
+      img {
+        margin-right: 3px;
+        height: 14px;
+        width: 14pxs;
+      }
+    }
   }
 }
 

--- a/dist/assets/scss/_utils.scss
+++ b/dist/assets/scss/_utils.scss
@@ -213,6 +213,9 @@
   &-large {
     font-size: 1.2em;
   }
+  &-small {
+    font-size: 0.8em !important;
+  }
 }
 
 .height-100 {

--- a/dist/components/App.js
+++ b/dist/components/App.js
@@ -288,9 +288,6 @@ var App = /*#__PURE__*/function (_React$Component) {
     });
 
     _defineProperty(_assertThisInitialized(_this), "setActiveFeature", function (feature) {
-      // if (typeof(window) !== 'undefined') {
-      //   window.location.hash = feature.properties.uid
-      // }
       _this.setState({
         activeFeature: feature
       });

--- a/dist/components/InteractiveMap.js
+++ b/dist/components/InteractiveMap.js
@@ -195,6 +195,10 @@ var InteractiveMap = /*#__PURE__*/function (_React$Component) {
           map.panTo(center);
         }
       }
+
+      if (!this.props.isMobile && !this.props.activeFeature && prevProps.activeFeature !== this.props.activeFeature) {
+        this.resetMap();
+      }
     }
   }, {
     key: "render",

--- a/dist/components/Splash.js
+++ b/dist/components/Splash.js
@@ -1,15 +1,33 @@
 "use strict";
 
+function _typeof(obj) { "@babel/helpers - typeof"; if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") { _typeof = function _typeof(obj) { return typeof obj; }; } else { _typeof = function _typeof(obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }; } return _typeof(obj); }
+
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.default = void 0;
 
-var _react = _interopRequireDefault(require("react"));
+var _react = _interopRequireWildcard(require("react"));
 
 var _propTypes = _interopRequireDefault(require("prop-types"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _getRequireWildcardCache() { if (typeof WeakMap !== "function") return null; var cache = new WeakMap(); _getRequireWildcardCache = function _getRequireWildcardCache() { return cache; }; return cache; }
+
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } if (obj === null || _typeof(obj) !== "object" && typeof obj !== "function") { return { default: obj }; } var cache = _getRequireWildcardCache(); if (cache && cache.has(obj)) { return cache.get(obj); } var newObj = {}; var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null; if (desc && (desc.get || desc.set)) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } newObj.default = obj; if (cache) { cache.set(obj, newObj); } return newObj; }
+
+function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _unsupportedIterableToArray(arr, i) || _nonIterableRest(); }
+
+function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
+
+function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
+
+function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
+
+function _iterableToArrayLimit(arr, i) { if (typeof Symbol === "undefined" || !(Symbol.iterator in Object(arr))) return; var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+
+function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
 
 var styles = {
   display: 'block',
@@ -25,6 +43,12 @@ var Splash = function Splash(_ref) {
       closeSplash = _ref.closeSplash,
       isMobile = _ref.isMobile,
       showSplash = _ref.showSplash;
+
+  var _useState = (0, _react.useState)(false),
+      _useState2 = _slicedToArray(_useState, 2),
+      showDisclaimer = _useState2[0],
+      setShowDisclaimer = _useState2[1];
+
   var visibilityClass = showSplash ? 'open' : 'closed';
   return /*#__PURE__*/_react.default.createElement(_react.default.Fragment, null, /*#__PURE__*/_react.default.createElement("button", {
     id: "toggle-splash",
@@ -48,13 +72,25 @@ var Splash = function Splash(_ref) {
     className: "title"
   }, "StreetARToronto - The Map!")), /*#__PURE__*/_react.default.createElement("p", {
     className: "text-italic"
-  }, "A joint project of StreetARToronto (StART) and Civic Hall Toronto"), /*#__PURE__*/_react.default.createElement("p", null, "Toronto is home to some of the best mural, street and graffiti artists and art in the world. These artists and artworks have transformed Toronto's public streets, laneways and parks into a city-wide art gallery!"), /*#__PURE__*/_react.default.createElement("p", null, "This map based app will help you explore the amazing street art located throughout the city. The current database provides a sampling of murals created as part of the StreetARToronto suite of programs from 2012 to 2019. In addition to identifying the artist and arts organization responsible for painting the mural, the database describes the stories and themes behind each unique and beautiful artwork."), /*#__PURE__*/_react.default.createElement("p", null, "Individually and collectively, these murals are designed to celebrate the City of Toronto motto \"Diversity Our Strength\" and foster a greater sense of belonging among all."), /*#__PURE__*/_react.default.createElement("p", null, "Filters allow you to search by any combination of Year and/or Ward. Additional filters will be installed and the database is being updated regularly to add more artwork, so check back often!"), /*#__PURE__*/_react.default.createElement("div", {
+  }, "A joint project of StreetARToronto (StART) and Civic Hall Toronto"), /*#__PURE__*/_react.default.createElement("p", null, "Toronto is home to some of the best mural, street and graffiti artists and art in the world. These artists and artworks have transformed Toronto's public streets, laneways and parks into a city-wide art gallery!"), /*#__PURE__*/_react.default.createElement("p", null, "This map based app will help you explore the amazing street art located throughout the city. The current database provides a sampling of murals created as part of the StreetARToronto suite of programs from 2012 to 2019. In addition to identifying the artist and arts organization responsible for painting the mural, the database describes the stories and themes behind each unique and beautiful artwork."), /*#__PURE__*/_react.default.createElement("p", null, "Individually and collectively, these murals are designed to celebrate the City of Toronto motto \"Diversity Our Strength\" and foster a greater sense of belonging among all."), /*#__PURE__*/_react.default.createElement("p", null, "Filters allow you to search by any combination of Year and/or Ward. Additional filters will be installed and the database is being updated regularly to add more artwork, so check back often!"), /*#__PURE__*/_react.default.createElement("ul", {
+    className: "splash-footer mt-6"
+  }, /*#__PURE__*/_react.default.createElement("li", null, /*#__PURE__*/_react.default.createElement("a", {
+    href: "https://www.toronto.ca/services-payments/streets-parking-transportation/enhancing-our-streets-and-public-realm/streetartoronto/",
+    target: "_blank",
+    rel: "noreferrer noopener"
+  }, "Website")), /*#__PURE__*/_react.default.createElement("li", null, /*#__PURE__*/_react.default.createElement("a", {
+    href: "https://www.youtube.com/playlist?list=PLp11YxteHNp1OVLdlHyA7QEc2bjCADGqJ",
+    target: "_blank",
+    rel: "noreferrer noopener"
+  }, "YouTube"))), /*#__PURE__*/_react.default.createElement("div", {
     className: "mt-6"
   }, /*#__PURE__*/_react.default.createElement("button", {
     "aria-label": "Close",
     onClick: closeSplash,
     className: "splash-btn btn btn-highlight btn-lg"
-  }, "Get Started!"))))), /*#__PURE__*/_react.default.createElement("div", {
+  }, "Get Started!")), /*#__PURE__*/_react.default.createElement("p", {
+    className: "text-muted text-small mt-6"
+  }, "All elements of the website, including, but not limited to, the general design and the content, are protected by copyright. Except as explicitly permitted under another the agreement between StreetARToronto and the Artist, no portion or element of this website or its content may be copied or retransmitted via any means and this website, its content and all related rights shall remain the exclusive property of StreetARToronto or its licensors.")))), /*#__PURE__*/_react.default.createElement("div", {
     className: "splash-background ".concat(visibilityClass),
     onClick: closeSplash,
     style: styles

--- a/dist/constants.js
+++ b/dist/constants.js
@@ -172,7 +172,7 @@ var DEFAULT_MAP_CENTER = {
 exports.DEFAULT_MAP_CENTER = DEFAULT_MAP_CENTER;
 var MAP_ZOOM_LEVEL = {
   DEFAULT: 12,
-  FEATURE: 18,
+  FEATURE: 17,
   MIN: 10
 };
 exports.MAP_ZOOM_LEVEL = MAP_ZOOM_LEVEL;
@@ -237,9 +237,9 @@ var MAP_STYLE_BASE = [{
   "stylers": [{
     "color": "#004b84"
   }, {
-    "lightness": "84"
+    "lightness": "87"
   }, {
-    "saturation": "-60"
+    "saturation": "-66"
   }]
 }, {
   "featureType": "poi",
@@ -317,9 +317,9 @@ var MAP_STYLE_BASE = [{
   }, {
     "visibility": "on"
   }, {
-    "saturation": "-64"
+    "saturation": "-70"
   }, {
-    "lightness": "40"
+    "lightness": "30"
   }, {
     "weight": "0.01"
   }]

--- a/public/index.html
+++ b/public/index.html
@@ -40,6 +40,6 @@
     <meta name="twitter:site" content="@StART_Toronto"/>
   </head>
   <body>
-    <div id="root"></div>
+    <div id="map-root"></div>
   </body>
 </html>

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ render(
     googleApiKey={env.REACT_APP_GOOGLE_MAPS_API_KEY}
     featuresDataSource={'geojson/ftrs.json'}
     wardsDataSource={'geojson/wards.json'}
-  />, document.getElementById("root"));
+  />, document.getElementById("map-root"));
 
 // If you want your app to work offline and load faster, you can change
 // unregister() to register() below. Note this comes with some pitfalls.

--- a/src/lib/assets/scss/_app.scss
+++ b/src/lib/assets/scss/_app.scss
@@ -30,7 +30,7 @@ time, mark, audio, video, button {
 	vertical-align: baseline;
 }
 
-#root, #start-map {
+#map-root, #start-map {
   width: 100%;
   height: 100%;
   display: block;

--- a/src/lib/assets/scss/_responsive.scss
+++ b/src/lib/assets/scss/_responsive.scss
@@ -1,5 +1,5 @@
 @media only screen and (max-width : 1024px) {
-  #root, #start-map {
+  #map-root, #start-map {
     width: 100vw;
     height: 100vh;
     position: fixed;


### PR DESCRIPTION
We are using some styles that affect `#root`, but then we import the whole start map into another app which has other expectations of `#root`. This makes them tread on one another in odd ways, which manifests as little glitches like this at certain breakpoints (note the button running over the edge of screen in this isolated component view)

## Before this PR

<img width="560" alt="Screen Shot 2020-11-02 at 5 05 00 PM" src="https://user-images.githubusercontent.com/305339/97924740-20beac00-1d2e-11eb-9083-4e6c24c5d124.png">

## After this PR

<img width="573" alt="Screen Shot 2020-11-02 at 5 04 40 PM" src="https://user-images.githubusercontent.com/305339/97924751-26b48d00-1d2e-11eb-93d7-ede44db601c1.png">